### PR TITLE
Refactor targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 
 _targets/*
+*/out/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 _targets/*
 */out/*
+

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,16 +1,11 @@
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
+combine_site_data <- function(file_path){
   
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
   data_out <- data.frame()
   # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
+  for (file in file_path){
     # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
+    these_data <- read_csv(file, col_types = 'ccTdcc')
     data_out <- bind_rows(data_out, these_data)
   }
   return(data_out)
@@ -24,11 +19,13 @@ nwis_site_info <- function(fileout, site_data){
 }
 
 
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
+download_nwis_site_data <- function(file_save_path, site_num, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
+  
+  file_path <- file.path(file_save_path, paste0('nwis_', site_num, '_data.csv'))
   
   # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
+  # remove the directory with basename() and extract the nwis site number with the regular expression match
+  site_num <- basename(file_path) %>% 
     stringr::str_extract(pattern = "(?:[0-9]+)")
   
   # readNWISdata is from the dataRetrieval package
@@ -42,7 +39,7 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  write_csv(data_out, file = file_path)
+  return(file_path)
 }
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,13 @@
-process_data <- function(nwis_data){
+process_data <- function(nwis_data,site_filename){
+  
+  site_info <- read_csv(site_filename)
+  
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, -tz_cd)
+    select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
+    left_join(., site_info, by = "site_no") %>% 
+    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va) %>% 
+    mutate(station_name = as.factor(station_name))
   
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
-  site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  
-  return(annotated_data)
-}
-
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
-}

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,6 +1,6 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(fileout, site_data_processed, width = 12, height = 7, units = 'in'){
   
-  ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
+  ggplot(data = site_data_processed, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)
   

--- a/_targets.R
+++ b/_targets.R
@@ -6,16 +6,39 @@ source("3_visualize/src/plot_timeseries.R")
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 
+site_nums <- c("01427207","01432160","01435000","01436690","01466500")
+
+p_width <- 12
+p_height <- 7
+p_units <- "in"
+
 p1_targets_list <- list(
   tar_target(
-    site_data,
-    download_nwis_data(),
-  ),
+    nwis_01427207_csv,
+    download_nwis_site_data(file_save_path = "1_fetch/out",site_num = site_nums[1]),
+    format="file"),
+  tar_target(
+    nwis_01432160_csv,
+    download_nwis_site_data(file_save_path = "1_fetch/out",site_num = site_nums[2]),
+    format="file"),
+  tar_target(
+    nwis_01435000_csv,
+    download_nwis_site_data(file_save_path = "1_fetch/out",site_num = site_nums[3]),
+    format="file"),
+  tar_target(
+    nwis_01436690_csv,
+    download_nwis_site_data(file_save_path = "1_fetch/out",site_num = site_nums[4]),
+    format="file"),
+  tar_target(
+    nwis_01466500_csv,
+    download_nwis_site_data(file_save_path = "1_fetch/out",site_num = site_nums[5]),
+    format="file"),
+  tar_target(
+    combined_site_data, 
+    combine_site_data(c(nwis_01427207_csv,nwis_01432160_csv,nwis_01435000_csv,nwis_01436690_csv,nwis_01466500_csv))),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
-    format = "file"
-  )
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv",combined_site_data))
 )
 
 p2_targets_list <- list(
@@ -36,7 +59,8 @@ p2_targets_list <- list(
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
+                         width = p_width, height = p_height, units = p_units),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -38,7 +38,8 @@ p1_targets_list <- list(
     combine_site_data(c(nwis_01427207_csv,nwis_01432160_csv,nwis_01435000_csv,nwis_01436690_csv,nwis_01466500_csv))),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv",combined_site_data))
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv",combined_site_data),
+    format="file")
 )
 
 p2_targets_list <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -43,16 +43,8 @@ p1_targets_list <- list(
 
 p2_targets_list <- list(
   tar_target(
-    site_data_clean, 
-    process_data(site_data)
-  ),
-  tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
-  ),
-  tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
+    site_data_processed, 
+    process_data(combined_site_data,site_info_csv)
   )
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -51,7 +51,7 @@ p2_targets_list <- list(
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_processed,
                          width = p_width, height = p_height, units = p_units),
     format = "file"
   )


### PR DESCRIPTION
Changes here resolve issue #5 . I refactored the pipeline to break up the data download step by site to make the code more robust to changes that only affect one site, or to download issues related to one site but not others. I created a separate target for each nwis site, although my solution here is not very scalable if we think we might add many more sites, for example. I'd be happy to get your feedback on that, or talk through ways to more efficiently scale the fetch phase of the pipeline.  

I also split up the data download steps from the step that combines the site data so that the original site_data target is smaller and those two functions (download and combine) are separate from one another. 

Since the clean, annotation, and style steps are related to one another and all relatively small tasks, I ended up combining these steps into one process_data function (and one corresponding target) in the data processing phase. Finally, I added the plot dimensions as explicit arguments to the plot_nwis_timeseries function so that the user can specify their desired dimensions. The graph below shows the dependencies within the pipeline given the changes I've described here. 

![image](https://user-images.githubusercontent.com/8785034/137369691-8f4b27d3-7cbb-4c10-82b2-3ffd70add762.png)
