### PR TITLE
Swap targets

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -11,11 +11,10 @@ combine_site_data <- function(file_path){
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
-  return(fileout)
+  return(site_info)
 }
 
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,6 +1,4 @@
-process_data <- function(nwis_data,site_filename){
-  
-  site_info <- read_csv(site_filename)
+process_data <- function(fileout,nwis_data,site_info){
   
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
@@ -8,6 +6,8 @@ process_data <- function(nwis_data,site_filename){
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va) %>% 
     mutate(station_name = as.factor(station_name))
   
-  return(nwis_data_clean)
+  write_csv(nwis_data_clean, file = fileout)
+  
+  return(fileout)
 }
 

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,4 +1,6 @@
-plot_nwis_timeseries <- function(fileout, site_data_processed, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(fileout, processed_data_file, width = 12, height = 7, units = 'in'){
+  
+  site_data_processed <- read_csv(processed_data_file)
   
   ggplot(data = site_data_processed, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,10 +1,9 @@
-plot_nwis_timeseries <- function(fileout, processed_data_file, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(processed_data_file){
   
   site_data_processed <- read_csv(processed_data_file)
   
-  ggplot(data = site_data_processed, aes(x = dateTime, y = water_temperature, color = station_name)) +
+  temp_plot <- ggplot(data = site_data_processed, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
-  ggsave(fileout, width = width, height = height, units = units)
-  
-  return(fileout)
+
+  return(temp_plot)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -43,15 +43,17 @@ p1_targets_list <- list(
 
 p2_targets_list <- list(
   tar_target(
-    site_data_processed, 
-    process_data(combined_site_data,site_info)
+    site_data_processed_csv, 
+    process_data(fileout = "2_process/out/site_data_processed.csv",combined_site_data,site_info),
+    format = "file"
   )
 )
 
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_processed,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", 
+                         processed_data_file = site_data_processed_csv,
                          width = p_width, height = p_height, units = p_units),
     format = "file"
   )

--- a/_targets.R
+++ b/_targets.R
@@ -37,15 +37,14 @@ p1_targets_list <- list(
     combined_site_data, 
     combine_site_data(c(nwis_01427207_csv,nwis_01432160_csv,nwis_01435000_csv,nwis_01436690_csv,nwis_01466500_csv))),
   tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv",combined_site_data),
-    format="file")
+    site_info,
+    nwis_site_info(combined_site_data))
 )
 
 p2_targets_list <- list(
   tar_target(
     site_data_processed, 
-    process_data(combined_site_data,site_info_csv)
+    process_data(combined_site_data,site_info)
   )
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -8,9 +8,6 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 
 site_nums <- c("01427207","01432160","01435000","01436690","01466500")
 
-p_width <- 12
-p_height <- 7
-p_units <- "in"
 
 p1_targets_list <- list(
   tar_target(
@@ -51,11 +48,8 @@ p2_targets_list <- list(
 
 p3_targets_list <- list(
   tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", 
-                         processed_data_file = site_data_processed_csv,
-                         width = p_width, height = p_height, units = p_units),
-    format = "file"
+    figure_1_draft,
+    plot_nwis_timeseries(processed_data_file = site_data_processed_csv)
   )
 )
 


### PR DESCRIPTION
This PR addresses issue #8. 

Since we are most interested in a few select columns of the site_info table (e.g. site name, spatial coordinates), I changed site_info from a file target to an object target. The columns we're interested in get joined with the processed data downstream in the pipeline, so it seems redundant to save as a file here. Instead of saving site_info as a file, I changed site_data_processed from an object target to a file target (now named site_data_processed_csv) since we may actually want to share that processed data, or pass it along to another pipeline.

In addition to the data changes above, I changed figure_1_png from a file target to an object target (now called figure_1_draft). I don't think this change will be very useful for most pipelines since loading the figure from a targets object is more cumbersome. However, here I'm treating the figure as a draft object while we test out other parts of the pipeline. 